### PR TITLE
Improve about page and add signup form

### DIFF
--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -12,31 +12,36 @@ export default function AboutPage() {
       </p>
 
       <h3 className="mt-10 font-semibold">What We Do</h3>
-      <h4 className="mt-6 font-semibold">Workshops</h4>
-      <p>
-        We organize community workshops where people from diverse backgrounds co-create with and critically reflect on AI systems. These sessions raise awareness and build understanding of both the benefits and harms of AI.
+      <p className="mt-6">
+        <strong>Workshops.</strong> We organize community workshops where people
+        from diverse backgrounds co-create with and critically reflect on AI
+        systems. These sessions raise awareness and build understanding of both
+        the benefits and harms of AI.
       </p>
-      <h4 className="mt-4 font-semibold">Research</h4>
-      <p>
-        We publish studies and open data focused on methods for public participation in the design, evaluation, and oversight of AI.
+      <p className="mt-4">
+        <strong>Research.</strong> We publish studies and open data focused on
+        methods for public participation in the design, evaluation, and
+        oversight of AI.
       </p>
-      <h4 className="mt-4 font-semibold">Advocacy</h4>
-      <p>
-        We advocate for the voices often excluded from AI policy and design—those most affected by automated systems but least consulted in their creation.
+      <p className="mt-4">
+        <strong>Advocacy.</strong> We advocate for the voices often excluded
+        from AI policy and design—those most affected by automated systems but
+        least consulted in their creation.
       </p>
 
       <h3 className="mt-10 font-semibold">Our Values</h3>
-      <h4 className="mt-6 font-semibold">Transparency and Open Source</h4>
-      <p>
-        We release data, code, and research findings under open licenses to support collective learning.
+      <p className="mt-6">
+        <strong>Transparency and Open Source.</strong> We release data, code, and
+        research findings under open licenses to support collective learning.
       </p>
-      <h4 className="mt-4 font-semibold">Pluralism</h4>
-      <p>
-        We work with people across cultures, languages, and perspectives to shape AI that reflects many ways of life.
+      <p className="mt-4">
+        <strong>Pluralism.</strong> We work with people across cultures,
+        languages, and perspectives to shape AI that reflects many ways of life.
       </p>
-      <h4 className="mt-4 font-semibold">Grassroots Engagement</h4>
-      <p>
-        We focus on building local knowledge and participation from the ground up, through workshops, partnerships, and direct community work.
+      <p className="mt-4">
+        <strong>Grassroots Engagement.</strong> We focus on building local
+        knowledge and participation from the ground up, through workshops,
+        partnerships, and direct community work.
       </p>
 
       <h3 className="mt-10 font-semibold">How You Can Help</h3>
@@ -45,6 +50,7 @@ export default function AboutPage() {
         <li>Join ongoing research projects on public participation in AI</li>
         <li>Make a donation – coming soon</li>
       </ul>
+      <p className="mt-6 text-accent">contact@therighttoai.org</p>
     </Section>
   );
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,12 +1,22 @@
 
 import Hero from "@/components/Hero";
 import { Section } from "@/components/Section";
+import EndorseForm from "@/components/EndorseForm";
 
 export default function Home() {
   return (
     <>
       <Hero />
-      
+
+      <Section id="endorse" title="Co-sign the Right to AI">
+        <p>
+          Individuals and entities who wish to co-sign in support of the values
+          and ideas it represents are invited to submit their contact
+          information below.
+        </p>
+        <EndorseForm />
+      </Section>
+
       <section id="poster" className="w-screen overflow-hidden">
         <img
           src="/poster.png"
@@ -19,9 +29,20 @@ export default function Home() {
 
       <Section id="declaration" title="Declaration of the Right to AI">
         <p>
-          AI shapes daily life—healthcare, finance, education, urban spaces—and everyone should have a real voice in how these systems are built, used, and governed. The Right to AI affirms that decisions about AI cannot be left to a small group of experts or corporations. People and communities must help define priorities, share in the oversight of data and technology, and ensure that AI reflects democratic values, social justice, and collective benefit. This declaration is open for any person or organization to endorse. By signing, you affirm that everyone—not only tech giants—has a stake in shaping AI that impacts daily life. Please click on "Get involved" to add your voice.
+          AI shapes daily life—healthcare, finance, education, urban spaces—and
+          everyone should have a real voice in how these systems are built, used,
+          and governed. The Right to AI affirms that decisions about AI cannot be
+          left to a small group of experts or corporations. People and
+          communities must help define priorities, share in the oversight of data
+          and technology, and ensure that AI reflects democratic values, social
+          justice, and collective benefit. This declaration is open for any
+          person or organization to endorse. By signing, you affirm that
+          everyone—not only tech giants—has a stake in shaping AI that impacts
+          daily life. Please click on
+          <a href="#endorse" className="text-accent font-medium">Get involved</a>
+          &nbsp;to add your voice.
         </p>
-        <div className="mt-6 flex flex-wrap gap-4">
+        <div className="mt-8 flex flex-wrap gap-4">
           <a
             href="/2501.17899v2.pdf"
             className="inline-block rounded border border-foreground px-6 py-2 text-foreground"
@@ -41,8 +62,11 @@ export default function Home() {
             Book
           </a>
         </div>
-      
-        <div className="mt-6 grid grid-cols-2 md:grid-cols-3 gap-y-1 text-xs text-gray-400">
+
+        <p className="mt-8 text-xs font-semibold text-gray-400">
+          Names for the Right to AI
+        </p>
+        <div className="mt-2 grid grid-cols-2 md:grid-cols-3 gap-y-1 text-xs text-gray-400">
           <span>Rashid Mushkani</span>
           <span>Hugo Berard</span>
           <span>Allison Cohen</span>
@@ -60,6 +84,7 @@ export default function Home() {
         </div>
 
       </Section>
+
       </>
   );
 }

--- a/components/EndorseForm.tsx
+++ b/components/EndorseForm.tsx
@@ -1,19 +1,95 @@
+"use client";
 
 export default function EndorseForm() {
-  // Replace the URL below with the published link of your Google Form once created
   return (
-    <div className="w-full">
-      <iframe
-        src="https://docs.google.com/forms/d/e/1FAIpQLSdYourFormIdHere/viewform?embedded=true"
-        width="100%"
-        height="900"
-        frameBorder="0"
-        marginHeight={0}
-        marginWidth={0}
-        className="w-full"
+    <form
+      action="mailto:contact@therighttoai.org?subject=Right%20to%20AI%20Support"
+      method="POST"
+      encType="text/plain"
+      className="mx-auto mt-8 max-w-md space-y-4 text-sm"
+    >
+      <div>
+        <label className="mb-1 block font-medium" htmlFor="name">
+          Name (of individual or organization)*
+        </label>
+        <input
+          id="name"
+          name="Name"
+          required
+          type="text"
+          className="w-full rounded border border-foreground bg-transparent px-3 py-2"
+        />
+      </div>
+      <div>
+        <label className="mb-1 block font-medium" htmlFor="email">
+          Email address*
+        </label>
+        <input
+          id="email"
+          name="Email"
+          required
+          type="email"
+          className="w-full rounded border border-foreground bg-transparent px-3 py-2"
+        />
+      </div>
+      <fieldset>
+        <legend className="mb-1 font-medium">
+          Would you like to join the Right to AI mailing list?
+        </legend>
+        <div className="flex gap-6">
+          <label>
+            <input
+              type="radio"
+              name="Join mailing list"
+              value="Yes"
+              required
+              className="mr-1"
+            />
+            Yes
+          </label>
+          <label>
+            <input type="radio" name="Join mailing list" value="No" className="mr-1" />
+            No
+          </label>
+        </div>
+      </fieldset>
+      <fieldset>
+        <legend className="mb-1 font-medium">
+          Would you like to volunteer or contribute to one of our ongoing projects?
+        </legend>
+        <div className="flex gap-6">
+          <label>
+            <input
+              type="radio"
+              name="Volunteer"
+              value="Yes"
+              required
+              className="mr-1"
+            />
+            Yes
+          </label>
+          <label>
+            <input type="radio" name="Volunteer" value="No" className="mr-1" />
+            No
+          </label>
+        </div>
+      </fieldset>
+      <div>
+        <label className="mb-1 block font-medium" htmlFor="comments">
+          Comments (optional)
+        </label>
+        <textarea
+          id="comments"
+          name="Comments"
+          className="w-full rounded border border-foreground bg-transparent px-3 py-2"
+        />
+      </div>
+      <button
+        type="submit"
+        className="mt-6 rounded border border-foreground px-6 py-2 text-sm"
       >
-        Loading…
-      </iframe>
-    </div>
+        Submit
+      </button>
+    </form>
   );
 }


### PR DESCRIPTION
## Summary
- overhaul About page layout
- integrate clickable call-to-action in Declaration text
- add contact form component and show it on homepage
- list names under a small title
- style contact email in red

## Testing
- `npm run lint` *(fails: prompts to set up ESLint)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6872e5595228832b9a7fa0d8231944d9