### PR TITLE
Implement modal endorsement form

### DIFF
--- a/app/api/endorse/route.ts
+++ b/app/api/endorse/route.ts
@@ -1,0 +1,31 @@
+import { NextRequest, NextResponse } from "next/server";
+import nodemailer from "nodemailer";
+
+export async function POST(req: NextRequest) {
+  const { name, email, joinMailingList, volunteer, comments } = await req.json();
+
+  const transporter = nodemailer.createTransport({
+    host: process.env.SMTP_HOST,
+    port: parseInt(process.env.SMTP_PORT || "587"),
+    secure: false,
+    auth: {
+      user: process.env.SMTP_USER,
+      pass: process.env.SMTP_PASS,
+    },
+  });
+
+  const message = {
+    from: process.env.SMTP_FROM || process.env.SMTP_USER,
+    to: "contact@therighttoai.org, rashidmushkani@gmail.com",
+    subject: "New Right to AI endorsement",
+    text: `Name: ${name}\nEmail: ${email}\nJoin mailing list: ${joinMailingList}\nVolunteer: ${volunteer}\nComments: ${comments || ""}`,
+  };
+
+  try {
+    await transporter.sendMail(message);
+    return NextResponse.json({ ok: true });
+  } catch (err) {
+    console.error(err);
+    return NextResponse.json({ ok: false }, { status: 500 });
+  }
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -3,6 +3,7 @@ import type { Metadata } from "next";
 import { Space_Grotesk } from "next/font/google";
 import { Header } from "@/components/Header";
 import { Footer } from "@/components/Footer";
+import Providers from "@/components/Providers";
 
 const spaceGrotesk = Space_Grotesk({ subsets: ["latin"], variable: "--font-space-grotesk" });
 
@@ -19,9 +20,11 @@ export default function RootLayout({
   return (
     <html lang="en" className={`${spaceGrotesk.className}`}>
       <body>
-        <Header />
-        <main>{children}</main>
-        <Footer />
+        <Providers>
+          <Header />
+          <main>{children}</main>
+          <Footer />
+        </Providers>
       </body>
     </html>
   );

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,21 +1,12 @@
 
 import Hero from "@/components/Hero";
 import { Section } from "@/components/Section";
-import EndorseForm from "@/components/EndorseForm";
+import GetInvolvedButton from "@/components/GetInvolvedButton";
 
 export default function Home() {
   return (
     <>
       <Hero />
-
-      <Section id="endorse" title="Co-sign the Right to AI">
-        <p>
-          Individuals and entities who wish to co-sign in support of the values
-          and ideas it represents are invited to submit their contact
-          information below.
-        </p>
-        <EndorseForm />
-      </Section>
 
       <section id="poster" className="w-screen overflow-hidden">
         <img
@@ -39,7 +30,7 @@ export default function Home() {
           person or organization to endorse. By signing, you affirm that
           everyone—not only tech giants—has a stake in shaping AI that impacts
           daily life. Please click on
-          <a href="#endorse" className="text-accent font-medium">Get involved</a>
+          <GetInvolvedButton className="text-accent font-medium" />
           &nbsp;to add your voice.
         </p>
         <div className="mt-8 flex flex-wrap gap-4">
@@ -63,7 +54,7 @@ export default function Home() {
           </a>
         </div>
 
-        <p className="mt-8 text-xs font-semibold text-gray-400">
+        <p className="mt-12 text-xs font-semibold text-gray-400">
           Names for the Right to AI
         </p>
         <div className="mt-2 grid grid-cols-2 md:grid-cols-3 gap-y-1 text-xs text-gray-400">

--- a/components/EndorseForm.tsx
+++ b/components/EndorseForm.tsx
@@ -1,11 +1,38 @@
 "use client";
+import { useState } from "react";
 
 export default function EndorseForm() {
+  const [submitted, setSubmitted] = useState(false);
+
+  async function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    const formData = new FormData(event.currentTarget);
+    const data = {
+      name: formData.get("Name"),
+      email: formData.get("Email"),
+      joinMailingList: formData.get("Join mailing list"),
+      volunteer: formData.get("Volunteer"),
+      comments: formData.get("Comments"),
+    };
+    await fetch("/api/endorse", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(data),
+    });
+    setSubmitted(true);
+  }
+
+  if (submitted) {
+    return (
+      <p className="mx-auto mt-8 max-w-md text-center text-sm">
+        Thank you for your endorsement!
+      </p>
+    );
+  }
+
   return (
     <form
-      action="mailto:contact@therighttoai.org?subject=Right%20to%20AI%20Support"
-      method="POST"
-      encType="text/plain"
+      onSubmit={handleSubmit}
       className="mx-auto mt-8 max-w-md space-y-4 text-sm"
     >
       <div>

--- a/components/EndorseModal.tsx
+++ b/components/EndorseModal.tsx
@@ -1,0 +1,22 @@
+"use client";
+import { useEndorseModal } from "./EndorseModalContext";
+import EndorseForm from "./EndorseForm";
+
+export default function EndorseModal() {
+  const { open, hide } = useEndorseModal();
+  if (!open) return null;
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/70">
+      <div className="relative rounded bg-background p-6 max-h-[90vh] overflow-auto">
+        <button
+          onClick={hide}
+          className="absolute right-2 top-2 text-foreground"
+          aria-label="Close"
+        >
+          ✕
+        </button>
+        <EndorseForm />
+      </div>
+    </div>
+  );
+}

--- a/components/EndorseModalContext.tsx
+++ b/components/EndorseModalContext.tsx
@@ -1,0 +1,23 @@
+"use client";
+import { createContext, useContext, useState, ReactNode } from "react";
+
+interface ModalContext {
+  open: boolean;
+  show: () => void;
+  hide: () => void;
+}
+
+const Context = createContext<ModalContext | undefined>(undefined);
+
+export function EndorseModalProvider({ children }: { children: ReactNode }) {
+  const [open, setOpen] = useState(false);
+  const show = () => setOpen(true);
+  const hide = () => setOpen(false);
+  return <Context.Provider value={{ open, show, hide }}>{children}</Context.Provider>;
+}
+
+export function useEndorseModal() {
+  const ctx = useContext(Context);
+  if (!ctx) throw new Error("useEndorseModal must be used within EndorseModalProvider");
+  return ctx;
+}

--- a/components/GetInvolvedButton.tsx
+++ b/components/GetInvolvedButton.tsx
@@ -1,0 +1,11 @@
+"use client";
+import { useEndorseModal } from "./EndorseModalContext";
+
+export default function GetInvolvedButton({ className }: { className?: string }) {
+  const { show } = useEndorseModal();
+  return (
+    <button type="button" onClick={show} className={className}>
+      Get involved
+    </button>
+  );
+}

--- a/components/Hero.tsx
+++ b/components/Hero.tsx
@@ -1,8 +1,10 @@
 
 "use client";
 import { motion } from "framer-motion";
+import { useEndorseModal } from "./EndorseModalContext";
 
 export default function Hero() {
+  const { show } = useEndorseModal();
   return (
     <section className="flex min-h-screen flex-col items-start justify-center px-4 md:px-24">
       <motion.span
@@ -32,13 +34,14 @@ export default function Hero() {
       >
         Not just AI for the people—AI by the people.
       </motion.p>
-      <motion.a
-        href="#endorse"
+      <motion.button
+        type="button"
+        onClick={show}
         whileHover={{ scale: 1.05 }}
         className="mt-10 rounded-full border border-foreground px-8 py-3 font-medium uppercase tracking-wide text-accent transition"
       >
         Get involved
-      </motion.a>
+      </motion.button>
     </section>
   );
 }

--- a/components/Providers.tsx
+++ b/components/Providers.tsx
@@ -1,0 +1,13 @@
+"use client";
+import { ReactNode } from "react";
+import { EndorseModalProvider } from "./EndorseModalContext";
+import EndorseModal from "./EndorseModal";
+
+export default function Providers({ children }: { children: ReactNode }) {
+  return (
+    <EndorseModalProvider>
+      {children}
+      <EndorseModal />
+    </EndorseModalProvider>
+  );
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,11 +10,13 @@
       "dependencies": {
         "framer-motion": "^11.0.0",
         "next": "14.1.0",
+        "nodemailer": "^6.9.11",
         "react": "18.2.0",
         "react-dom": "18.2.0"
       },
       "devDependencies": {
         "@types/node": "24.0.13",
+        "@types/nodemailer": "^6.4.17",
         "@types/react": "19.1.8",
         "autoprefixer": "^10.4.14",
         "eslint": "^8.57.0",
@@ -539,6 +541,16 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.8.0"
+      }
+    },
+    "node_modules/@types/nodemailer": {
+      "version": "6.4.17",
+      "resolved": "https://registry.npmjs.org/@types/nodemailer/-/nodemailer-6.4.17.tgz",
+      "integrity": "sha512-I9CCaIp6DTldEg7vyUTZi8+9Vo0hi1/T8gv3C89yk1rSAAzoKQ8H8ki/jBYJSFoH/BisgLP8tkZMlQ91CIquww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@types/react": {
@@ -4114,6 +4126,15 @@
       "integrity": "sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/nodemailer": {
+      "version": "6.10.1",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-6.10.1.tgz",
+      "integrity": "sha512-Z+iLaBGVaSjbIzQ4pX6XV41HrooLsQ10ZWPUehGmuantvzWoDVBnmsdUcOIDM1t+yPor5pDhVlDESgOMEGxhHA==",
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=6.0.0"
+      }
     },
     "node_modules/normalize-path": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -11,11 +11,13 @@
   "dependencies": {
     "framer-motion": "^11.0.0",
     "next": "14.1.0",
+    "nodemailer": "^6.9.11",
     "react": "18.2.0",
     "react-dom": "18.2.0"
   },
   "devDependencies": {
     "@types/node": "24.0.13",
+    "@types/nodemailer": "^6.4.17",
     "@types/react": "19.1.8",
     "autoprefixer": "^10.4.14",
     "eslint": "^8.57.0",

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -8,7 +8,7 @@ module.exports = {
     extend: {
       colors: {
         background: "#000000",
-        accent: "#FF0000",
+        accent: "#8B0000",
         foreground: "#FFFFFF"
       },
       fontFamily: {


### PR DESCRIPTION
## Summary
- switch accent color to dark red
- show endorsement form in modal popup triggered by "Get involved" links
- submit form data to new `/api/endorse` endpoint using nodemailer
- adjust layout to support modal provider and enlarge spacing above names list

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687315a1ee80832b8febcc07ab3be6b2