### PR TITLE
Fix accent color and book image

### DIFF
--- a/app/book/page.tsx
+++ b/app/book/page.tsx
@@ -14,7 +14,7 @@ export default function BookPage() {
           alt="Right to AI book cover"
           width={400}
           height={600}
-          className="mb-6 h-auto w-auto"
+          className="mb-6 h-auto w-auto border border-gray-200"
         />
         <p className="text-lg">Coming soon</p>
       </div>

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Allow: /

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -8,7 +8,7 @@ module.exports = {
     extend: {
       colors: {
         background: "#000000",
-        accent: "#8B0000",
+        accent: "#FF0000",
         foreground: "#FFFFFF"
       },
       fontFamily: {


### PR DESCRIPTION
## Summary
- restore bright red accent color
- show a light frame around book cover
- add `robots.txt` to allow indexing

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68731b89cbf0832bb2758c0dc671d9bb