### PR TITLE
Make poster full width and enlarge intro text

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -8,7 +8,7 @@ export default function Home() {
     <>
       <Hero />
       <Section id="declaration" title="Declaration of the Right to AI">
-        <p>
+        <p className="text-lg">
           AI shapes daily life—healthcare, finance, education, urban spaces—and
           everyone should have a real voice in how these systems are built, used,
           and governed. The Right to AI affirms that decisions about AI cannot be

--- a/app/poster/page.tsx
+++ b/app/poster/page.tsx
@@ -7,14 +7,14 @@ export const metadata = {
 
 export default function PosterPage() {
   return (
-    <Section id="poster" title="Poster">
+    <Section id="poster" title="Poster" fullWidth>
       <div className="flex justify-center">
         <Image
           src="/poster.png"
           alt="Right to AI explanatory poster"
-          width={800}
-          height={1200}
-          className="h-auto w-full max-w-3xl border border-gray-200"
+          width={1200}
+          height={1800}
+          className="h-auto w-full border border-gray-200"
         />
       </div>
     </Section>

--- a/components/Section.tsx
+++ b/components/Section.tsx
@@ -5,14 +5,19 @@ import { ReactNode } from "react";
 export function Section({
   id,
   title,
-  children
+  children,
+  fullWidth = false,
 }: {
   id?: string;
   title: string;
   children: ReactNode;
+  fullWidth?: boolean;
 }) {
   return (
-    <section id={id} className="mx-auto max-w-3xl px-4 py-20">
+    <section
+      id={id}
+      className={`mx-auto px-4 py-20 ${fullWidth ? '' : 'max-w-3xl'}`}
+    >
       <h2 className="mb-8 text-3xl font-semibold tracking-wide">{title}</h2>
       <div className="space-y-6 text-base leading-relaxed">{children}</div>
     </section>


### PR DESCRIPTION
## Summary
- make Section component optionally full-width
- show poster image across the full viewport width
- enlarge introductory text on home page for better readability

## Testing
- `npm run lint` *(fails: prompts for ESLint config)*

------
https://chatgpt.com/codex/tasks/task_e_687353fb847c832bba0c737d87980f60