### PR TITLE
Improve SEO metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,8 @@ This site hosts interactive content, public-facing explanations of AI infrastruc
 - A declaration that invites individuals and organizations to co-sign the Right to AI  
 - Educational content on how AI affects public space, finance, health, and daily life  
 - Materials for community workshops and participatory research  
-- Opportunities to volunteer, contribute, or stay informed through a mailing list  
+- Opportunities to volunteer, contribute, or stay informed through a mailing list
+- Built-in sitemap and `robots.txt` for better indexing on search engines
 
 
 ## Getting Started

--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -2,6 +2,8 @@ import Section from '@/components/Section';
 
 export const metadata = {
   title: 'About – The Right to AI',
+  description: 'Learn about the Right to AI organization and how we work with communities.',
+  alternates: { canonical: '/about' },
 };
 
 export default function AboutPage() {

--- a/app/book/page.tsx
+++ b/app/book/page.tsx
@@ -3,6 +3,8 @@ import Section from '@/components/Section';
 
 export const metadata = {
   title: 'Book – The Right to AI',
+  description: 'Information about the upcoming Right to AI book.',
+  alternates: { canonical: '/book' },
 };
 
 export default function BookPage() {

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -8,8 +8,16 @@ import Providers from "@/components/Providers";
 const spaceGrotesk = Space_Grotesk({ subsets: ["latin"], variable: "--font-space-grotesk" });
 
 export const metadata: Metadata = {
+  metadataBase: new URL("https://www.therighttoai.org"),
   title: "The Right to AI",
-  description: "AI for All. Voices for AI."
+  description: "AI for All. Voices for AI.",
+  alternates: {
+    canonical: "/",
+  },
+  robots: {
+    index: true,
+    follow: true,
+  },
 };
 
 export default function RootLayout({

--- a/app/poster/page.tsx
+++ b/app/poster/page.tsx
@@ -3,6 +3,8 @@ import Section from '@/components/Section';
 
 export const metadata = {
   title: 'Poster \u2013 The Right to AI',
+  description: 'Download or view the Right to AI informational poster.',
+  alternates: { canonical: '/poster' },
 };
 
 export default function PosterPage() {

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,2 +1,3 @@
 User-agent: *
 Allow: /
+Sitemap: https://www.therighttoai.org/sitemap.xml


### PR DESCRIPTION
## Summary
- add canonical URLs and robots directives to layout
- add descriptions and canonical paths to about, book, and poster pages
- reference sitemap in `robots.txt`
- document sitemap support in README

## Testing
- `npm run lint` *(fails: prompts to configure ESLint)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_688bb9d81fa0832b9359bc0d39a51dc7